### PR TITLE
fix: correct agent template paths from .ai-dev/prompts/ to ai-dev/pro…

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -1,6 +1,6 @@
 # GitHub Copilot Integration for AI Dev Playbook
 
-This directory contains files that enable GitHub Copilot to provide AI assistance that follows the AI Dev Playbook methodology. These files complement the traditional workflow using agent templates in the `.ai-dev/prompts/` directory.
+This directory contains files that enable GitHub Copilot to provide AI assistance that follows the AI Dev Playbook methodology. These files complement the traditional workflow using agent templates in the `ai-dev/prompts/` directory.
 
 ## Contents
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -12,7 +12,7 @@ This repository follows the AI Dev Playbook methodology, a structured approach t
 
 ## Project Structure
 
-- **Agent Prompts**: Specialized prompt templates are stored in `.ai-dev/prompts/` directory. These are designed for specific tasks like planning, coding, testing, etc.
+- **Agent Prompts**: Specialized prompt templates are stored in `ai-dev/prompts/` directory. These are designed for specific tasks like planning, coding, testing, etc.
 - **Memory Directory**: Transient outputs are stored in `.ai-dev/memory/` as a "scratchpad" for the development workflow. Note the dot prefix - this directory is separate from the primary prompt directory to ensure generated files are not committed.
 - **Project Ledger**: The `AIDEV.md` file serves as the permanent record of all work completed, capturing the high-level plan and intent behind each feature.
 - **Template Variables**: Project-specific variables are defined in `.ai-dev/config/variables.json` and can be referenced in prompts using `{{VARIABLE_NAME}}` syntax.

--- a/.github/prompts/incident-fix.prompt.md
+++ b/.github/prompts/incident-fix.prompt.md
@@ -36,7 +36,7 @@ Review an incident triage report and propose both immediate hotfix and sustainab
 
 **Next Steps:**
 Use this prompt with the Specification Agent:
-> "Using @workspace .ai-dev/prompts/00-specification-agent.md, create a technical specification to address [describe the incident and desired outcome]..."
+> "Using @workspace ai-dev/prompts/00-specification-agent.md, create a technical specification to address [describe the incident and desired outcome]..."
 
 ### Implementation Timeline
 - **Immediate:** Deploy hotfix

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ This workflow is built on a few key ideas:
 | **Spec-Driven Development** | Specifications before code | Create detailed specifications (requirements, design, API contracts) before implementation for better quality and maintainability. |
 | **External Tool Integration** | Kiro, Spec Kit support | The AI Dev Playbook seamlessly integrates with existing specification tools like Amazon's Kiro and GitHub's Spec Kit, allowing teams to leverage their existing planning workflows. |
 | **Specification Sources** | Multiple input formats | Accept specifications from various sources: manual creation, Kiro design documents, Spec Kit artifacts, or existing documentation, providing flexibility for different team workflows. |
-| **Specialized Agents** | .ai-dev/prompts/ | A collection of prompt templates, each designed for a specific task (specifications, planning, coding, testing, incident management, etc.). You invoke these agents to perform work. |
+| **Specialized Agents** | ai-dev/prompts/ | A collection of prompt templates, each designed for a specific task (specifications, planning, coding, testing, incident management, etc.). You invoke these agents to perform work. |
 | **Role-Based Prompting** | Expert personas in each agent | By assigning specific roles (e.g., "Martin Fowler for refactoring," "Richard Feynman for documentation"), we focus the AI's vast knowledge and trigger deep expert associations, just like telling a human to "think like a security expert." This provides more accurate, expert-level responses. |
 | **GitHub Copilot Integration** | .github/ directory | Repository custom instructions and prompt files that provide the same guidance through native GitHub Copilot features. |
 | **Workspace Context** | @workspace command | GitHub Copilot can read files directly from your workspace. You use this to provide context like requirements, existing code, or plans. |
@@ -183,13 +183,13 @@ First, we ask the **Specification Developer Agent** to create detailed specifica
 
 **Your Chat Prompt:**
 
-"Using the agent at @workspace .ai-dev/prompts/00-specification-agent.md, create a comprehensive specification for a new API endpoint /api/items. The endpoint should fetch data from itemService.js and return it as JSON. Include requirements, design, API contract, and testing strategy. Save the output to @workspace .ai-dev/memory/get-items-spec.md."
+"Using the agent at @workspace ai-dev/prompts/00-specification-agent.md, create a comprehensive specification for a new API endpoint /api/items. The endpoint should fetch data from itemService.js and return it as JSON. Include requirements, design, API contract, and testing strategy. Save the output to @workspace .ai-dev/memory/get-items-spec.md."
 
 **Option B: Multiple Specification Files:**
 
 **Your Chat Prompt:**
 
-"Using the agent at @workspace .ai-dev/prompts/00-specification-agent.md, create separate specification files for a new API endpoint /api/items. The endpoint should fetch data from itemService.js and return it as JSON. Create requirements.md, design.md, and api-contract.md files in the .ai-dev/memory/ directory."
+"Using the agent at @workspace ai-dev/prompts/00-specification-agent.md, create separate specification files for a new API endpoint /api/items. The endpoint should fetch data from itemService.js and return it as JSON. Create requirements.md, design.md, and api-contract.md files in the .ai-dev/memory/ directory."
 
 ### **Step 2: Plan the Work**
 
@@ -197,7 +197,7 @@ Next, we ask the **Planner Agent** to break down the task based on our specifica
 
 **Your Chat Prompt:**
 
-"Using the agent at @workspace .ai-dev/prompts/01-planner-agent.md, create a plan to implement the API endpoint based on the specifications in @workspace .ai-dev/memory/get-items-spec.md. Save the output to @workspace .ai-dev/memory/get-items-plan.md."
+"Using the agent at @workspace ai-dev/prompts/01-planner-agent.md, create a plan to implement the API endpoint based on the specifications in @workspace .ai-dev/memory/get-items-spec.md. Save the output to @workspace .ai-dev/memory/get-items-plan.md."
 
 ### **Step 3: Estimate the Work**
 
@@ -205,7 +205,7 @@ Before implementation, we use the **Estimator Agent** to get time and complexity
 
 **Your Chat Prompt:**
 
-"Using @workspace .ai-dev/prompts/02-estimator-agent.md, provide time and complexity estimates for the plan in @workspace .ai-dev/memory/get-items-plan.md. Save the output to @workspace .ai-dev/memory/get-items-estimates.md."
+"Using @workspace ai-dev/prompts/02-estimator-agent.md, provide time and complexity estimates for the plan in @workspace .ai-dev/memory/get-items-plan.md. Save the output to @workspace .ai-dev/memory/get-items-estimates.md."
 
 ### **Step 4: Write the Code**
 
@@ -213,7 +213,7 @@ Now, we execute the plan step-by-step using the **Coder Agent**.
 
 **Your Chat Prompt:**
 
-"Using @workspace .ai-dev/prompts/03-coder-agent.md, implement Step 1 from the plan in @workspace .ai-dev/memory/get-items-plan.md."
+"Using @workspace ai-dev/prompts/03-coder-agent.md, implement Step 1 from the plan in @workspace .ai-dev/memory/get-items-plan.md."
 
 ### **Step 5: Write the Tests**
 
@@ -221,7 +221,7 @@ With the code written, we ask the **Tester Agent** to create the tests.
 
 **Your Chat Prompt:**
 
-"Using @workspace .ai-dev/prompts/04-tester-agent.md, write unit tests for the new getItems function in @workspace src/services/itemService.js. Ensure you test the happy path and that it returns an array."
+"Using @workspace ai-dev/prompts/04-tester-agent.md, write unit tests for the new getItems function in @workspace src/services/itemService.js. Ensure you test the happy path and that it returns an array."
 
 ### **Step 6: Review and Refine**
 
@@ -233,7 +233,7 @@ If implementation details changed during development, we update our specificatio
 
 **Your Chat Prompt:**
 
-"Using @workspace .ai-dev/prompts/06-documenter-agent.md, update the specifications in @workspace .ai-dev/memory/get-items-spec.md to reflect any changes made during implementation."
+"Using @workspace ai-dev/prompts/06-documenter-agent.md, update the specifications in @workspace .ai-dev/memory/get-items-spec.md to reflect any changes made during implementation."
 
 ### **Step 8: Archive the History**
 
@@ -241,11 +241,11 @@ The feature is complete\! The final step is to use the **Archiver Agent** to cre
 
 **Your Chat Prompt:**
 
-"Using @workspace .ai-dev/prompts/08-archiver-agent.md, create a new entry in @workspace AIDEV.md titled 'Feature: Add /api/items Endpoint'. Compile the plan from @workspace .ai-dev/memory/get-items-plan.md into it."
+"Using @workspace ai-dev/prompts/08-archiver-agent.md, create a new entry in @workspace AIDEV.md titled 'Feature: Add /api/items Endpoint'. Compile the plan from @workspace .ai-dev/memory/get-items-plan.md into it."
 
 ## **Governance and Best Practices**
 
-* **Prompts are Curated:** The agent prompts in .ai-dev/prompts are the team's standard. Do not commit changes to them directly. If you discover a generally useful improvement, open a Pull Request to discuss it.  
+* **Prompts are Curated:** The agent prompts in ai-dev/prompts are the team's standard. Do not commit changes to them directly. If you discover a generally useful improvement, open a Pull Request to discuss it.  
 * **AIDEV.md is the Project's Ledger:** This file is the project's long-term memory. The final step of every task is to append its story (plan, etc.) to this ledger. This ensures the "why" behind your code is preserved for future developers. You must include the updated AIDEV.md in your feature's Pull Request and be prepared to resolve merge conflicts.  
 * **⚠️ SECURITY WARNING:** **NEVER** paste secrets, credentials, or sensitive customer data into a prompt. The AI is a third-party service. Use placeholders and reference environment variables, just as you would in your code.
 
@@ -287,10 +287,10 @@ The AI Dev Playbook now offers two complementary approaches to AI-assisted devel
 
 ### 1. Traditional Workflow with Agent Templates
 
-Use the `@workspace` command with agent templates in `.ai-dev/prompts/` for a structured, full-featured workflow:
+Use the `@workspace` command with agent templates in `ai-dev/prompts/` for a structured, full-featured workflow:
 
 ```
-Using @workspace .ai-dev/prompts/01-planner-agent.md, create a plan for...
+Using @workspace ai-dev/prompts/01-planner-agent.md, create a plan for...
 ```
 
 This approach is ideal for complex features and teams following the complete methodology.

--- a/WHATS-NEW.md
+++ b/WHATS-NEW.md
@@ -82,7 +82,7 @@ For teams adopting these new techniques, we recommend starting with:
 
 All enhancements are available in both formats:
 
-**Traditional Workflow** (`@workspace .ai-dev/prompts/`):
+**Traditional Workflow** (`@workspace ai-dev/prompts/`):
 - 12 enhanced agent templates with expert personas (including Incident Management)
 - Advanced context engineering capabilities
 - New Compactor Agent for context management

--- a/ai-dev/prompts/09-compactor-agent.md
+++ b/ai-dev/prompts/09-compactor-agent.md
@@ -63,6 +63,6 @@ Provide a structured markdown document with these sections:
 
 **USAGE EXAMPLES:**
 
-"Using @workspace .ai-dev/prompts/09-compactor-agent.md, please summarize our conversation about implementing user authentication. Focus on preserving the key architectural decisions and the current implementation status."
+"Using @workspace ai-dev/prompts/09-compactor-agent.md, please summarize our conversation about implementing user authentication. Focus on preserving the key architectural decisions and the current implementation status."
 
-"Using @workspace .ai-dev/prompts/09-compactor-agent.md, compact the accumulated context in @workspace .ai-dev/memory/user-auth-context.md and create a focused summary for the next development phase."
+"Using @workspace ai-dev/prompts/09-compactor-agent.md, compact the accumulated context in @workspace .ai-dev/memory/user-auth-context.md and create a focused summary for the next development phase."

--- a/ai-dev/prompts/11-incident-fix-agent.md
+++ b/ai-dev/prompts/11-incident-fix-agent.md
@@ -54,7 +54,7 @@ This approach addresses the root cause to prevent this and similar issues from r
 **Next Step: Generate a Formal Specification**
 To implement this correctly, use the following prompt with the Specification agent:
 
-> "Using @workspace .ai-dev/prompts/00-specification-agent.md, create a technical specification to address the incident described in the following report: [Paste Triage Report Here]. The goal is to refactor the user loading mechanism in `processOrder` to be more resilient and ensure a valid user object is always present. The specification should define new validation rules and error handling for when a user cannot be loaded."
+> "Using @workspace ai-dev/prompts/00-specification-agent.md, create a technical specification to address the incident described in the following report: [Paste Triage Report Here]. The goal is to refactor the user loading mechanism in `processOrder` to be more resilient and ensure a valid user object is always present. The specification should define new validation rules and error handling for when a user cannot be loaded."
 
 ### 4. Implementation Timeline Recommendation
 * **Immediate (0-2 hours):** Deploy hotfix to stop the bleeding

--- a/ai-docs/adoption-guide.md
+++ b/ai-docs/adoption-guide.md
@@ -72,7 +72,7 @@ Integrating the AI Dev Playbook into a mature codebase requires a simple "drop-i
    * The docs/ directory (or just docs/ai-dev-playbook-workflow.md, docs/github-copilot-integration.md, and this docs/adoption-guide.md).  
 2. **No Code Changes Required:** This action should require **zero modifications** to your existing application source code. The AI Dev Playbook assets will sit alongside your current /src, /app, /tests directories.  
 3. **(Optional) Tune the Prompts and Instructions:** Your team should take a few minutes to tune both the agent prompts and GitHub Copilot instructions to your project's specific context:
-   * For agent templates: Add project-specific context to files in `.ai-dev/prompts/`. For example, you might add a line to 03-coder-agent.md like: *"This is a Java Spring Boot application using Maven. Ensure all code follows standard Java 17 conventions and our internal style guide."*
+   * For agent templates: Add project-specific context to files in `ai-dev/prompts/`. For example, you might add a line to 03-coder-agent.md like: *"This is a Java Spring Boot application using Maven. Ensure all code follows standard Java 17 conventions and our internal style guide."*
    * For GitHub Copilot: Customize `.github/copilot-instructions.md` with your project's coding standards, architecture, and other important context. Also review and update the prompt files in `.github/prompts/` to align with your team's needs.
    * Consider using template variables in `.ai-dev/config/variables.json` to maintain consistency across both systems.  
 4. **Initialize AIDEV.md:** You do not need to retroactively document your entire project. Instead, create an initial entry in AIDEV.md to mark the start of the new process.  
@@ -103,7 +103,7 @@ mv requirements.md .ai-dev/memory/
 mv tasks.md .ai-dev/memory/
 
 # Use AI Dev Playbook to consolidate and implement
-Using @workspace .ai-dev/prompts/00-specification-agent.md, analyze and consolidate the Kiro documents in @workspace .ai-dev/memory/ into a unified technical specification.
+Using @workspace ai-dev/prompts/00-specification-agent.md, analyze and consolidate the Kiro documents in @workspace .ai-dev/memory/ into a unified technical specification.
 ```
 
 ### **For Teams Using Spec Kit**
@@ -120,7 +120,7 @@ Using @workspace .ai-dev/prompts/00-specification-agent.md, analyze and consolid
 cp specs/[###-feature-name]/*.md .ai-dev/memory/
 
 # Execute tasks directly with AI Dev Playbook
-Using @workspace .ai-dev/prompts/03-coder-agent.md, implement Task T001 from @workspace .ai-dev/memory/tasks.md.
+Using @workspace ai-dev/prompts/03-coder-agent.md, implement Task T001 from @workspace .ai-dev/memory/tasks.md.
 ```
 
 ### **Benefits of Integration**

--- a/ai-docs/ai-dev-playbook-workflow.md
+++ b/ai-docs/ai-dev-playbook-workflow.md
@@ -10,7 +10,7 @@ The goal is to move beyond mechanical prompting and into a fluid, conversational
 
 The AI Dev Playbook now offers two complementary approaches to AI-assisted development:
 
-1. **Traditional Workflow**: Using `@workspace` commands with agent templates in `.ai-dev/prompts/`
+1. **Traditional Workflow**: Using `@workspace` commands with agent templates in `ai-dev/prompts/`
 2. **GitHub Copilot Native Integration**: Using repository custom instructions and prompt files
 
 This document primarily describes the traditional workflow. For details on the GitHub Copilot native integration, see [github-copilot-integration.md](github-copilot-integration.md).
@@ -49,7 +49,7 @@ For complex features or production code, start with creating detailed specificat
 1. **Understand the Requirements:** Gather all available information about the feature request, user story, or bug ticket.
 
 2. **Invoke the Specification Developer Agent:** Select a **reasoning model** and ask the agent to create comprehensive specifications.
-   * **Example Prompt:** "Using @workspace .ai-dev/prompts/00-specification-agent.md, create detailed specifications for the user authentication feature described in @workspace docs/tickets/AUTH-123.md. Save the specifications to @workspace .ai-dev/memory/AUTH-123-spec.md."
+   * **Example Prompt:** "Using @workspace ai-dev/prompts/00-specification-agent.md, create detailed specifications for the user authentication feature described in @workspace docs/tickets/AUTH-123.md. Save the specifications to @workspace .ai-dev/memory/AUTH-123-spec.md."
 
 3. **Review and Refine the Specifications:** Carefully review the generated specifications for accuracy, completeness, and alignment with project goals. Make any necessary adjustments.
 
@@ -58,11 +58,11 @@ For complex features or production code, start with creating detailed specificat
 If you already have specifications from external tools, adapt them for the AI Dev Playbook workflow:
 
 **From Kiro Artifacts:**
-   * **Example Prompt:** "Using @workspace .ai-dev/prompts/00-specification-agent.md, analyze and consolidate the design documents in @workspace .ai-dev/memory/ (design.md, requirements.md, tasks.md from Kiro) into a unified technical specification. Save to @workspace .ai-dev/memory/consolidated-spec.md."
+   * **Example Prompt:** "Using @workspace ai-dev/prompts/00-specification-agent.md, analyze and consolidate the design documents in @workspace .ai-dev/memory/ (design.md, requirements.md, tasks.md from Kiro) into a unified technical specification. Save to @workspace .ai-dev/memory/consolidated-spec.md."
 
 **From Spec Kit Artifacts:**
    * Since Spec Kit provides constitution-based planning, you can often proceed directly to task execution
-   * **Example Prompt:** "Using @workspace .ai-dev/prompts/01-planner-agent.md, review and validate the implementation plan in @workspace .ai-dev/memory/plan.md (from Spec Kit). Ensure it aligns with our project requirements and update if needed."
+   * **Example Prompt:** "Using @workspace ai-dev/prompts/01-planner-agent.md, review and validate the implementation plan in @workspace .ai-dev/memory/plan.md (from Spec Kit). Ensure it aligns with our project requirements and update if needed."
 
 4. **Use Specifications as Living Documentation:** These specifications will guide all subsequent phases and should be updated if requirements or implementation details change.
 
@@ -76,7 +76,7 @@ With specifications in hand (or for simpler features), proceed to planning. A hi
    * **Provide Context:** Use the @workspace command to point the AI to relevant files. This could include the ticket description, related code, or architectural diagrams.  
    * **Direct the Output:** Always tell the agent where to save the plan, creating a new file in the .ai-dev/memory/ directory (note the dot prefix - this hidden directory is separate from the ai-dev/prompts/ directory).
 
-**Example Prompt:**"Using @workspace .ai-dev/prompts/01-planner-agent.md, create a detailed plan for the feature described in @workspace docs/tickets/TICKET-123.md. Consider the existing code in @workspace src/auth/utils.js. Save the plan to @workspace .ai-dev/memory/TICKET-123-plan.md."
+**Example Prompt:**"Using @workspace ai-dev/prompts/01-planner-agent.md, create a detailed plan for the feature described in @workspace docs/tickets/TICKET-123.md. Consider the existing code in @workspace src/auth/utils.js. Save the plan to @workspace .ai-dev/memory/TICKET-123-plan.md."
 
 3. **Review and Refine the Plan:** The AI's first plan is a draft, not a final command. Read it carefully. Does it make sense? Did it miss anything? If the plan is flawed, ask the AI to revise it."That's a good start, but you forgot to include a step for adding rate limiting to the new endpoint. Please update the plan in @workspace .ai-dev/memory/TICKET-123-plan.md to include this."
 
@@ -88,7 +88,7 @@ Before diving into implementation, get time and complexity estimates to help wit
    * **Be Specific:** Provide any context about team experience or constraints that might affect estimates.
    * **Direct the Output:** Save the estimates to a file in the .ai-dev/memory/ directory.
 
-**Example Prompt:** "Using @workspace .ai-dev/prompts/02-estimator-agent.md, provide time and complexity estimates for the plan in @workspace .ai-dev/memory/TICKET-123-plan.md. Our team has moderate experience with the technologies involved. Save the estimates to @workspace .ai-dev/memory/TICKET-123-estimates.md."
+**Example Prompt:** "Using @workspace ai-dev/prompts/02-estimator-agent.md, provide time and complexity estimates for the plan in @workspace .ai-dev/memory/TICKET-123-plan.md. Our team has moderate experience with the technologies involved. Save the estimates to @workspace .ai-dev/memory/TICKET-123-estimates.md."
 
 2. **Review the Estimates:** Examine the time and complexity estimates. Do they align with your expectations? If the estimates reveal that certain steps are more complex or time-consuming than anticipated, you might want to:
    * Break down complex steps into smaller, more manageable tasks
@@ -113,11 +113,11 @@ Coder Agent → Tester Agent → Run Tests → Evaluate Results
 
 2. **Enforce Minimal Code:** The Coder agent is explicitly instructed to write the minimum code necessary. When you review its output, ensure it has followed this rule. If it adds extra helper functions or logic that wasn't in the plan, ask it to revise and remove the unnecessary code.
    
-   **Example Prompt:** "Using @workspace .ai-dev/prompts/03-coder-agent.md, please implement Step 1 ('Create Service File') from the plan in @workspace .ai-dev/memory/TICKET-123-plan.md."
+   **Example Prompt:** "Using @workspace ai-dev/prompts/03-coder-agent.md, please implement Step 1 ('Create Service File') from the plan in @workspace .ai-dev/memory/TICKET-123-plan.md."
 
 3. **Test Immediately:** Once a logical unit of code is complete, immediately ask the Tester agent to write comprehensive tests including evaluation tests.
    
-   **Example Prompt:** "Using @workspace .ai-dev/prompts/04-tester-agent.md, write comprehensive tests including evaluation tests for the code in src/services/itemService.js. Include tests that measure AI consistency and correctness."
+   **Example Prompt:** "Using @workspace ai-dev/prompts/04-tester-agent.md, write comprehensive tests including evaluation tests for the code in src/services/itemService.js. Include tests that measure AI consistency and correctness."
 
 4. **Run and Evaluate Tests:** Execute the tests locally and analyze the results:
    * **Unit Tests**: Do they pass? Do they cover edge cases?
@@ -144,7 +144,7 @@ Once the core functionality is built and tested, use the specialized agents to i
 
 1. **Refactor for Clarity:** Using a **reasoning model**, ask the Refactorer agent to clean up any complex or duplicative code.  
 2. **Perform a Security Review:** This is a crucial final check. Use a powerful **reasoning model** to ensure the Security Reviewer agent can analyze the code for subtle vulnerabilities.  
-   **Example Prompt:**"Please perform a security review of the new endpoint handler in src/routes/api.js using @workspace .ai-dev/prompts/07-security-reviewer-agent.md."  
+   **Example Prompt:**"Please perform a security review of the new endpoint handler in src/routes/api.js using @workspace ai-dev/prompts/07-security-reviewer-agent.md."  
 3. **Add Documentation:** Use the Documenter agent with a **reasoning model** to generate clear, human-readable documentation.
 
 ### Phase 5: Archival & Completion
@@ -152,7 +152,7 @@ Once the core functionality is built and tested, use the specialized agents to i
 This final phase ensures your work becomes a permanent, useful part of the project's history.
 
 1. **Invoke the Archiver:** This is your last AI command for the task. Point the Archiver agent to all the relevant files you created in the /memory directory.  
-   **Example Prompt:**"Using @workspace .ai-dev/prompts/08-archiver-agent.md, create a new entry in @workspace AIDEV.md titled 'Feature \#123: User Login Endpoint'. Compile the following files into it: @workspace .ai-dev/memory/TICKET-123-plan.md and @workspace .ai-dev/memory/TICKET-123-security-review.md."  
+   **Example Prompt:**"Using @workspace ai-dev/prompts/08-archiver-agent.md, create a new entry in @workspace AIDEV.md titled 'Feature \#123: User Login Endpoint'. Compile the following files into it: @workspace .ai-dev/memory/TICKET-123-plan.md and @workspace .ai-dev/memory/TICKET-123-security-review.md."  
 2. **Review the AIDEV.md Entry:** Briefly check the AIDEV.md file to ensure the new entry was appended correctly and looks clean.  
 3. **Clean Up:** Delete the files for your task from the .ai-dev/memory/ directory. Their purpose is served, and their story is now in AIDEV.md. These files should never be committed to version control.  
 4. **Submit Your Pull Request:** Commit all your changes, including the updated AIDEV.md. When you create your PR, you can even reference the AIDEV.md entry in your description to give reviewers instant context.
@@ -165,11 +165,11 @@ When following this workflow in a monorepo, remember that all @workspace file pa
 
 **Correct Monorepo Prompt:**
 
-"Using @workspace apps/my-api/.ai-dev/prompts/02-coder-agent.md, implement the plan from @workspace apps/my-api/.ai-dev/memory/plan.md."
+"Using @workspace apps/my-api/ai-dev/prompts/02-coder-agent.md, implement the plan from @workspace apps/my-api/.ai-dev/memory/plan.md."
 
 **Incorrect Monorepo Prompt (ambiguous):**
 
-"Using @workspace .ai-dev/prompts/02-coder-agent.md..."
+"Using @workspace ai-dev/prompts/02-coder-agent.md..."
 
 ### Using Template Variables
 
@@ -207,7 +207,7 @@ To make agent prompts more adaptable to your specific project needs, you can use
    When invoking an agent, include the variables file in your prompt:
 
    ```
-   Using @workspace .ai-dev/prompts/02-coder-agent.md with variables from @workspace .ai-dev/config/variables.json, implement...
+   Using @workspace ai-dev/prompts/02-coder-agent.md with variables from @workspace .ai-dev/config/variables.json, implement...
    ```
 
 #### Best Practices for Template Variables
@@ -240,7 +240,7 @@ When a production issue occurs, start with systematic diagnosis:
 
    **Example Prompt:**
    ```
-   Using @workspace .ai-dev/prompts/10-incident-triage-agent.md, analyze the following production error: 
+   Using @workspace ai-dev/prompts/10-incident-triage-agent.md, analyze the following production error: 
    [paste error message, stack trace, and any relevant context]
    ```
 
@@ -260,7 +260,7 @@ With the root cause identified, determine the best path forward:
 
    **Example Prompt:**
    ```
-   Using @workspace .ai-dev/prompts/11-incident-fix-agent.md, propose solutions for the incident triaged in @workspace .ai-dev/memory/incident-triage-report.md
+   Using @workspace ai-dev/prompts/11-incident-fix-agent.md, propose solutions for the incident triaged in @workspace .ai-dev/memory/incident-triage-report.md
    ```
 
 2. **Evaluate Fix Options**: The agent will provide:
@@ -291,7 +291,7 @@ With the root cause identified, determine the best path forward:
 
    **Example Prompt:**
    ```
-   Using @workspace .ai-dev/prompts/08-archiver-agent.md, create an entry in @workspace AIDEV.md titled 'Incident: [Brief Description]' documenting the triage and fix from @workspace .ai-dev/memory/
+   Using @workspace ai-dev/prompts/08-archiver-agent.md, create an entry in @workspace AIDEV.md titled 'Incident: [Brief Description]' documenting the triage and fix from @workspace .ai-dev/memory/
    ```
 
 2. **Update Runbooks**: If the incident reveals operational gaps, update monitoring, alerting, or documentation

--- a/ai-docs/executive-briefing.md
+++ b/ai-docs/executive-briefing.md
@@ -54,7 +54,7 @@ The AI Dev Playbook addresses these challenges by providing:
 
 The AI Dev Playbook offers two complementary integration options:
 
-1. **Traditional Workflow**: Structured process using specialized agent templates (`.ai-dev/prompts/`) for complex features
+1. **Traditional Workflow**: Structured process using specialized agent templates (`ai-dev/prompts/`) for complex features
 2. **GitHub Copilot Native Integration**: Lightweight approach using repository custom instructions (`.github/copilot-instructions.md`) and prompt files (`.github/prompts/*.prompt.md`) for quick tasks
 
 Teams can choose either approach or combine them based on their specific needs:

--- a/ai-docs/github-copilot-integration.md
+++ b/ai-docs/github-copilot-integration.md
@@ -32,7 +32,7 @@ GitHub Copilot's prompt files feature allows you to save common prompt instructi
 ### How It Works
 
 1. The `.github/prompts/` directory contains `.prompt.md` files for each agent type
-2. These files mirror the functionality of our agent templates in `.ai-dev/prompts/`
+2. These files mirror the functionality of our agent templates in `ai-dev/prompts/`
 3. You can reference them directly in GitHub Copilot Chat using the `@prompt` command
 
 For example:
@@ -71,7 +71,7 @@ Use the traditional AI Dev Playbook workflow with `@workspace` commands when:
 
 Example:
 ```
-Using @workspace .ai-dev/prompts/01-planner-agent.md, create a plan for...
+Using @workspace ai-dev/prompts/01-planner-agent.md, create a plan for...
 ```
 
 ### Quick Tasks with Prompt Files

--- a/ai-docs/governance-and-sustainability.md
+++ b/ai-docs/governance-and-sustainability.md
@@ -8,7 +8,7 @@ To ensure the AI Dev Playbook works effectively across distributed teams, adopt 
 
 ### Managing Templates and Prompts
 
-- **Centralized Curation**: Agent templates (`.ai-dev/prompts/`) and GitHub Copilot prompts (`.github/prompts/`) should be centrally curated
+- **Centralized Curation**: Agent templates (`ai-dev/prompts/`) and GitHub Copilot prompts (`.github/prompts/`) should be centrally curated
 - **Change Process**: Changes to core templates should be made via Pull Request with appropriate review
 - **Local Adaptations**: Developers are encouraged to adapt prompts locally for specific tasks but should not commit those tweaks to main
 - **Template Variables**: Use template variables (`.ai-dev/config/variables.json`) to customize prompts without modifying core templates
@@ -129,7 +129,7 @@ Establish clear workflows for reviewing and approving AI-generated code:
   "AI Dev Planner": {
     "prefix": "aidp-plan",
     "body": [
-      "Using @workspace .ai-dev/prompts/01-planner-agent.md, create a plan for $1. Save the output to @workspace .ai-dev/memory/$2."
+      "Using @workspace ai-dev/prompts/01-planner-agent.md, create a plan for $1. Save the output to @workspace .ai-dev/memory/$2."
     ]
   }
   ```

--- a/ai-docs/spec-driven-development.md
+++ b/ai-docs/spec-driven-development.md
@@ -97,7 +97,7 @@ Use the AI Dev Playbook's built-in Specification Agent for custom spec generatio
 
 **1. Create Initial Specification**
 ```
-Using @workspace .ai-dev/prompts/00-specification-agent.md, create a comprehensive feature specification for [feature description]
+Using @workspace ai-dev/prompts/00-specification-agent.md, create a comprehensive feature specification for [feature description]
 ```
 
 **2. Choose Document Structure**
@@ -133,7 +133,7 @@ mv tasks.md .ai-dev/memory/
 
 **3. Consolidate and Refine**
 ```
-Using @workspace .ai-dev/prompts/00-specification-agent.md, analyze and consolidate the Kiro documents in @workspace .ai-dev/memory/ into a unified technical specification.
+Using @workspace ai-dev/prompts/00-specification-agent.md, analyze and consolidate the Kiro documents in @workspace .ai-dev/memory/ into a unified technical specification.
 ```
 
 #### **Using GitHub Spec Kit**
@@ -157,7 +157,7 @@ cp specs/[###-feature-name]/*.md .ai-dev/memory/
 
 **3. Execute with AI Dev Playbook**
 ```
-Using @workspace .ai-dev/prompts/03-coder-agent.md, implement Task T001 from @workspace .ai-dev/memory/tasks.md.
+Using @workspace ai-dev/prompts/03-coder-agent.md, implement Task T001 from @workspace .ai-dev/memory/tasks.md.
 ```
 
 ### **Approach 3: Hybrid Integration**
@@ -182,7 +182,7 @@ Combine external tool strengths with AI Dev Playbook refinement:
 Use the Planner Agent to break down specifications into discrete tasks (works with specifications from any source):
 
 ```
-Using @workspace .ai-dev/prompts/01-planner-agent.md, create a task list based on the specifications in @workspace .ai-dev/memory/
+Using @workspace ai-dev/prompts/01-planner-agent.md, create a task list based on the specifications in @workspace .ai-dev/memory/
 ```
 
 ### 3. Implement with Continuous Reference to Specs
@@ -190,7 +190,7 @@ Using @workspace .ai-dev/prompts/01-planner-agent.md, create a task list based o
 When implementing code, always reference the specification documents:
 
 ```
-Using @workspace .ai-dev/prompts/03-coder-agent.md, implement the API endpoint described in @workspace .ai-dev/memory/api-contract.md
+Using @workspace ai-dev/prompts/03-coder-agent.md, implement the API endpoint described in @workspace .ai-dev/memory/api-contract.md
 ```
 
 ### 4. Keep Documentation in Sync
@@ -198,7 +198,7 @@ Using @workspace .ai-dev/prompts/03-coder-agent.md, implement the API endpoint d
 Update specification documents when implementation details change:
 
 ```
-Using @workspace .ai-dev/prompts/06-documenter-agent.md, update the design document at @workspace .ai-dev/memory/design.md to reflect the changes made to the authentication flow
+Using @workspace ai-dev/prompts/06-documenter-agent.md, update the design document at @workspace .ai-dev/memory/design.md to reflect the changes made to the authentication flow
 ```
 
 ## **Plan-Centric Code Reviews**
@@ -256,13 +256,13 @@ The spec-driven approach extends beyond development into production incident man
 ### **Example Workflow**
 ```
 # 1. Systematic Analysis
-Using @workspace .ai-dev/prompts/10-incident-triage-agent.md, analyze this production error and identify root causes.
+Using @workspace ai-dev/prompts/10-incident-triage-agent.md, analyze this production error and identify root causes.
 
 # 2. Balanced Response Planning  
-Using @workspace .ai-dev/prompts/11-incident-fix-agent.md, propose both hotfix and sustainable solutions.
+Using @workspace ai-dev/prompts/11-incident-fix-agent.md, propose both hotfix and sustainable solutions.
 
 # 3. Spec-Driven Sustainable Fix
-Using @workspace .ai-dev/prompts/00-specification-agent.md, create specifications for the long-term solution to address the underlying design issues identified in the incident analysis.
+Using @workspace ai-dev/prompts/00-specification-agent.md, create specifications for the long-term solution to address the underlying design issues identified in the incident analysis.
 ```
 
 This approach ensures that incidents become opportunities for system improvement rather than just quick patches.

--- a/docs/documents-first-guide.md
+++ b/docs/documents-first-guide.md
@@ -228,7 +228,7 @@ Because Spec Kit has already generated a detailed plan (`plan.md`) and task list
 **2. Execute Tasks**: Begin executing the steps outlined in `.ai-dev/memory/tasks.md` using the Coder Agent. Since the tasks are already defined, you can start implementation immediately.
 
 ```bash
-Using @workspace .ai-dev/prompts/03-coder-agent.md, implement Task T001 from @workspace .ai-dev/memory/tasks.md.
+Using @workspace ai-dev/prompts/03-coder-agent.md, implement Task T001 from @workspace .ai-dev/memory/tasks.md.
 ```
 
 **3. Follow the Workflow**: Continue with the standard AI Dev Playbook workflow (Test → Secure → Document → Archive) for each implemented task.
@@ -259,7 +259,7 @@ This approach keeps your permanent documentation organized while ensuring the AI
 
 **1. Analyze Your Existing Documents**
 ```bash
-Using @workspace .ai-dev/prompts/00-specification-agent.md, analyze the design documents in @workspace .ai-dev/memory/ (design.md, requirements.md, tasks.md) and create a consolidated technical specification that includes:
+Using @workspace ai-dev/prompts/00-specification-agent.md, analyze the design documents in @workspace .ai-dev/memory/ (design.md, requirements.md, tasks.md) and create a consolidated technical specification that includes:
 - System requirements and constraints
 - Architecture and design decisions
 - API specifications and data models
@@ -270,7 +270,7 @@ Save to @workspace .ai-dev/memory/consolidated-spec.md.
 
 **2. Create Initial Implementation Plan**
 ```bash
-Using @workspace .ai-dev/prompts/01-planner-agent.md, create a comprehensive implementation plan based on the consolidated specification in @workspace .ai-dev/memory/consolidated-spec.md and the task breakdown in @workspace .ai-dev/memory/tasks.md. Organize work into phases:
+Using @workspace ai-dev/prompts/01-planner-agent.md, create a comprehensive implementation plan based on the consolidated specification in @workspace .ai-dev/memory/consolidated-spec.md and the task breakdown in @workspace .ai-dev/memory/tasks.md. Organize work into phases:
 1. Project setup and infrastructure
 2. Core functionality implementation
 3. Integration and testing
@@ -280,7 +280,7 @@ Save to @workspace .ai-dev/memory/implementation-plan.md.
 
 **3. Estimate Work and Complexity**
 ```bash
-Using @workspace .ai-dev/prompts/02-estimator-agent.md, provide detailed time and complexity estimates for the implementation plan in @workspace .ai-dev/memory/implementation-plan.md. Consider:
+Using @workspace ai-dev/prompts/02-estimator-agent.md, provide detailed time and complexity estimates for the implementation plan in @workspace .ai-dev/memory/implementation-plan.md. Consider:
 - Technology stack setup time
 - Development complexity by feature
 - Testing and integration effort
@@ -292,7 +292,7 @@ Save to @workspace .ai-dev/memory/project-estimates.md.
 
 **1. Determine Technology Stack**
 ```bash
-Using @workspace .ai-dev/prompts/03-coder-agent.md, based on the consolidated specification in @workspace .ai-dev/memory/consolidated-spec.md, recommend and set up the initial project structure including:
+Using @workspace ai-dev/prompts/03-coder-agent.md, based on the consolidated specification in @workspace .ai-dev/memory/consolidated-spec.md, recommend and set up the initial project structure including:
 - Technology stack selection
 - Project directory structure
 - Build and dependency management setup
@@ -302,7 +302,7 @@ Using @workspace .ai-dev/prompts/03-coder-agent.md, based on the consolidated sp
 
 **2. Create Project Foundation**
 ```bash
-Using @workspace .ai-dev/prompts/03-coder-agent.md, implement Phase 1 (Project setup and infrastructure) from @workspace .ai-dev/memory/implementation-plan.md. Focus on:
+Using @workspace ai-dev/prompts/03-coder-agent.md, implement Phase 1 (Project setup and infrastructure) from @workspace .ai-dev/memory/implementation-plan.md. Focus on:
 - Basic project structure
 - Build system configuration
 - Essential dependencies
@@ -317,12 +317,12 @@ Since Spec Kit provides constitution-aligned planning, you can often start direc
 
 **1. Review Generated Plan**
 ```bash
-Using @workspace .ai-dev/prompts/01-planner-agent.md, review and validate the implementation plan in @workspace .ai-dev/memory/plan.md. Ensure it aligns with your project requirements and constraints. If modifications are needed, update the plan accordingly.
+Using @workspace ai-dev/prompts/01-planner-agent.md, review and validate the implementation plan in @workspace .ai-dev/memory/plan.md. Ensure it aligns with your project requirements and constraints. If modifications are needed, update the plan accordingly.
 ```
 
 **2. Validate Task Breakdown**
 ```bash
-Using @workspace .ai-dev/prompts/02-estimator-agent.md, review the task list in @workspace .ai-dev/memory/tasks.md and provide time estimates for each task. Identify any dependencies or potential roadblocks.
+Using @workspace ai-dev/prompts/02-estimator-agent.md, review the task list in @workspace .ai-dev/memory/tasks.md and provide time estimates for each task. Identify any dependencies or potential roadblocks.
 ```
 
 **Phase 2: Direct Implementation**
@@ -331,12 +331,12 @@ Since Spec Kit has already done the heavy planning work, you can begin implement
 
 **1. Execute Spec Kit Tasks**
 ```bash
-Using @workspace .ai-dev/prompts/03-coder-agent.md, implement Task T001 from @workspace .ai-dev/memory/tasks.md as specified in the plan.
+Using @workspace ai-dev/prompts/03-coder-agent.md, implement Task T001 from @workspace .ai-dev/memory/tasks.md as specified in the plan.
 ```
 
 **2. Continue Sequential Implementation**
 ```bash
-Using @workspace .ai-dev/prompts/03-coder-agent.md, implement Task T002 from @workspace .ai-dev/memory/tasks.md, ensuring it builds on the previous task.
+Using @workspace ai-dev/prompts/03-coder-agent.md, implement Task T002 from @workspace .ai-dev/memory/tasks.md, ensuring it builds on the previous task.
 ```
 
 ### Common Iterative Development (Both Use Cases)
@@ -349,32 +349,32 @@ Now follow the standard AI Dev Playbook workflow for each feature/phase:
 
 1. **Create Detailed Specifications** (if needed for Kiro workflows)
 ```bash
-Using @workspace .ai-dev/prompts/00-specification-agent.md, create detailed specifications for [specific feature] based on the requirements in @workspace .ai-dev/memory/consolidated-spec.md. Save to @workspace .ai-dev/memory/[feature-name]-spec.md.
+Using @workspace ai-dev/prompts/00-specification-agent.md, create detailed specifications for [specific feature] based on the requirements in @workspace .ai-dev/memory/consolidated-spec.md. Save to @workspace .ai-dev/memory/[feature-name]-spec.md.
 ```
 
 2. **Plan Implementation** (if needed for Kiro workflows)
 ```bash
-Using @workspace .ai-dev/prompts/01-planner-agent.md, create implementation steps for [specific feature] based on @workspace .ai-dev/memory/[feature-name]-spec.md. Save to @workspace .ai-dev/memory/[feature-name]-plan.md.
+Using @workspace ai-dev/prompts/01-planner-agent.md, create implementation steps for [specific feature] based on @workspace .ai-dev/memory/[feature-name]-spec.md. Save to @workspace .ai-dev/memory/[feature-name]-plan.md.
 ```
 
 3. **Implement Features**
 ```bash
-Using @workspace .ai-dev/prompts/03-coder-agent.md, implement Step [X] from @workspace .ai-dev/memory/[feature-name]-plan.md.
+Using @workspace ai-dev/prompts/03-coder-agent.md, implement Step [X] from @workspace .ai-dev/memory/[feature-name]-plan.md.
 ```
 
 4. **Write Tests**
 ```bash
-Using @workspace .ai-dev/prompts/04-tester-agent.md, write comprehensive tests for the [feature] implementation including evaluation tests for quality measurement.
+Using @workspace ai-dev/prompts/04-tester-agent.md, write comprehensive tests for the [feature] implementation including evaluation tests for quality measurement.
 ```
 
 5. **Security Review**
 ```bash
-Using @workspace .ai-dev/prompts/07-security-reviewer-agent.md, review the [feature] implementation for security concerns.
+Using @workspace ai-dev/prompts/07-security-reviewer-agent.md, review the [feature] implementation for security concerns.
 ```
 
 6. **Archive Progress**
 ```bash
-Using @workspace .ai-dev/prompts/08-archiver-agent.md, create an entry in @workspace AIDEV.md titled 'Feature: [Feature Name]' documenting the implementation.
+Using @workspace ai-dev/prompts/08-archiver-agent.md, create an entry in @workspace AIDEV.md titled 'Feature: [Feature Name]' documenting the implementation.
 ```
 
 ## Advantages of This Approach

--- a/docs/greenfield-project-guide.md
+++ b/docs/greenfield-project-guide.md
@@ -156,7 +156,7 @@ your-project/
 **Test the workflow** by running a simple validation:
 ```bash
 # Traditional workflow test
-Using @workspace .ai-dev/prompts/00-specification-agent.md, create a technical specification for a simple "Hello World" feature that demonstrates your project's basic functionality. Save to @workspace .ai-dev/memory/hello-world-spec.md.
+Using @workspace ai-dev/prompts/00-specification-agent.md, create a technical specification for a simple "Hello World" feature that demonstrates your project's basic functionality. Save to @workspace .ai-dev/memory/hello-world-spec.md.
 
 # GitHub Copilot workflow test (from project root)
 @prompt create-spec
@@ -180,37 +180,37 @@ Select a simple but representative feature that demonstrates your project's core
 
 **1. Create Technical Specification**
 ```bash
-Using @workspace .ai-dev/prompts/00-specification-agent.md, create a comprehensive technical specification for [your chosen feature]. Include interfaces, data structures, error handling, and integration points. Save to @workspace .ai-dev/memory/[feature-name]-spec.md.
+Using @workspace ai-dev/prompts/00-specification-agent.md, create a comprehensive technical specification for [your chosen feature]. Include interfaces, data structures, error handling, and integration points. Save to @workspace .ai-dev/memory/[feature-name]-spec.md.
 ```
 
 **2. Plan Implementation**
 ```bash
-Using @workspace .ai-dev/prompts/01-planner-agent.md, create a detailed implementation plan based on the specification in @workspace .ai-dev/memory/[feature-name]-spec.md. Break down into implementable steps with clear acceptance criteria. Save to @workspace .ai-dev/memory/[feature-name]-plan.md.
+Using @workspace ai-dev/prompts/01-planner-agent.md, create a detailed implementation plan based on the specification in @workspace .ai-dev/memory/[feature-name]-spec.md. Break down into implementable steps with clear acceptance criteria. Save to @workspace .ai-dev/memory/[feature-name]-plan.md.
 ```
 
 **3. Implement the Feature**
 ```bash
-Using @workspace .ai-dev/prompts/03-coder-agent.md, implement Step 1 from the plan in @workspace .ai-dev/memory/[feature-name]-plan.md. Focus on clean, maintainable code that follows the specification.
+Using @workspace ai-dev/prompts/03-coder-agent.md, implement Step 1 from the plan in @workspace .ai-dev/memory/[feature-name]-plan.md. Focus on clean, maintainable code that follows the specification.
 ```
 
 **4. Write Comprehensive Tests**
 ```bash
-Using @workspace .ai-dev/prompts/04-tester-agent.md, write comprehensive unit tests for the implemented feature. Include happy path, error cases, and edge conditions as defined in the specification.
+Using @workspace ai-dev/prompts/04-tester-agent.md, write comprehensive unit tests for the implemented feature. Include happy path, error cases, and edge conditions as defined in the specification.
 ```
 
 **5. Security Review**
 ```bash
-Using @workspace .ai-dev/prompts/07-security-reviewer-agent.md, review the implementation for security concerns. Ensure proper input validation, error handling, and no sensitive data exposure.
+Using @workspace ai-dev/prompts/07-security-reviewer-agent.md, review the implementation for security concerns. Ensure proper input validation, error handling, and no sensitive data exposure.
 ```
 
 **6. Create Documentation**
 ```bash
-Using @workspace .ai-dev/prompts/06-documenter-agent.md, create user and developer documentation for the implemented feature. Include usage examples and API documentation.
+Using @workspace ai-dev/prompts/06-documenter-agent.md, create user and developer documentation for the implemented feature. Include usage examples and API documentation.
 ```
 
 **7. Archive the Work**
 ```bash
-Using @workspace .ai-dev/prompts/08-archiver-agent.md, create a comprehensive entry in @workspace AIDEV.md titled 'Feature: [Your Feature Name]'. Include the specification, plan, implementation summary, and lessons learned.
+Using @workspace ai-dev/prompts/08-archiver-agent.md, create a comprehensive entry in @workspace AIDEV.md titled 'Feature: [Your Feature Name]'. Include the specification, plan, implementation summary, and lessons learned.
 ```
 
 ### Step 3: Establish Development Patterns
@@ -271,7 +271,7 @@ Let's walk through a complete example of implementing a "Configuration Validatio
 
 **1. Create Technical Specification**
 ```bash
-Using @workspace .ai-dev/prompts/00-specification-agent.md, create a comprehensive technical specification for a configuration validation system. The system should:
+Using @workspace ai-dev/prompts/00-specification-agent.md, create a comprehensive technical specification for a configuration validation system. The system should:
 - Read configuration files (JSON/YAML)
 - Validate required fields and data types
 - Provide clear error messages with suggestions
@@ -289,7 +289,7 @@ Save to @workspace .ai-dev/memory/config-validation-spec.md.
 
 **2. Create Implementation Plan**
 ```bash
-Using @workspace .ai-dev/prompts/01-planner-agent.md, create a detailed implementation plan based on the specification in @workspace .ai-dev/memory/config-validation-spec.md. Break down the work into these phases:
+Using @workspace ai-dev/prompts/01-planner-agent.md, create a detailed implementation plan based on the specification in @workspace .ai-dev/memory/config-validation-spec.md. Break down the work into these phases:
 1. Core validation engine
 2. Configuration parser
 3. Error reporting system
@@ -306,7 +306,7 @@ Save to @workspace .ai-dev/memory/config-validation-plan.md.
 
 **3. Implement Core Functionality**
 ```bash
-Using @workspace .ai-dev/prompts/03-coder-agent.md, implement Step 1 from the plan in @workspace .ai-dev/memory/config-validation-plan.md. Focus on the core validation engine with:
+Using @workspace ai-dev/prompts/03-coder-agent.md, implement Step 1 from the plan in @workspace .ai-dev/memory/config-validation-plan.md. Focus on the core validation engine with:
 - Clean, maintainable code structure
 - Proper error handling
 - Type safety (if applicable to your language)
@@ -321,7 +321,7 @@ Using @workspace .ai-dev/prompts/03-coder-agent.md, implement Step 1 from the pl
 
 **4. Write Comprehensive Tests**
 ```bash
-Using @workspace .ai-dev/prompts/04-tester-agent.md, write comprehensive unit tests for the validation engine. Include:
+Using @workspace ai-dev/prompts/04-tester-agent.md, write comprehensive unit tests for the validation engine. Include:
 - Valid configuration scenarios
 - Invalid configuration scenarios  
 - Edge cases (empty files, malformed data)
@@ -337,7 +337,7 @@ Using @workspace .ai-dev/prompts/04-tester-agent.md, write comprehensive unit te
 
 **5. Security Review**
 ```bash
-Using @workspace .ai-dev/prompts/07-security-reviewer-agent.md, review the configuration validation implementation for security concerns:
+Using @workspace ai-dev/prompts/07-security-reviewer-agent.md, review the configuration validation implementation for security concerns:
 - Input sanitization
 - File access permissions
 - Injection attack prevention
@@ -353,7 +353,7 @@ Using @workspace .ai-dev/prompts/07-security-reviewer-agent.md, review the confi
 
 **6. Create Documentation**
 ```bash
-Using @workspace .ai-dev/prompts/06-documenter-agent.md, create comprehensive documentation for the configuration validation system:
+Using @workspace ai-dev/prompts/06-documenter-agent.md, create comprehensive documentation for the configuration validation system:
 - User guide with examples
 - API documentation
 - Configuration schema reference
@@ -369,7 +369,7 @@ Using @workspace .ai-dev/prompts/06-documenter-agent.md, create comprehensive do
 
 **7. Archive the Work**
 ```bash
-Using @workspace .ai-dev/prompts/08-archiver-agent.md, create a comprehensive entry in @workspace AIDEV.md titled 'Feature: Configuration Validation System'. Include:
+Using @workspace ai-dev/prompts/08-archiver-agent.md, create a comprehensive entry in @workspace AIDEV.md titled 'Feature: Configuration Validation System'. Include:
 - Original specification summary
 - Implementation approach and decisions
 - Testing strategy and results
@@ -430,29 +430,29 @@ This example shows how the AI Dev Playbook methodology ensures that even your fi
 **Traditional Workflow:**
 ```bash
 # 1. Specification
-Using @workspace .ai-dev/prompts/00-specification-agent.md, create a technical specification for [feature]. Save to @workspace .ai-dev/memory/[name]-spec.md.
+Using @workspace ai-dev/prompts/00-specification-agent.md, create a technical specification for [feature]. Save to @workspace .ai-dev/memory/[name]-spec.md.
 
 # 2. Planning  
-Using @workspace .ai-dev/prompts/01-planner-agent.md, create an implementation plan based on @workspace .ai-dev/memory/[name]-spec.md. Save to @workspace .ai-dev/memory/[name]-plan.md.
+Using @workspace ai-dev/prompts/01-planner-agent.md, create an implementation plan based on @workspace .ai-dev/memory/[name]-spec.md. Save to @workspace .ai-dev/memory/[name]-plan.md.
 
 # 3. Implementation
-Using @workspace .ai-dev/prompts/03-coder-agent.md, implement Step 1 from @workspace .ai-dev/memory/[name]-plan.md.
+Using @workspace ai-dev/prompts/03-coder-agent.md, implement Step 1 from @workspace .ai-dev/memory/[name]-plan.md.
 
 # 4. Testing
-Using @workspace .ai-dev/prompts/04-tester-agent.md, write comprehensive tests for the implemented feature.
+Using @workspace ai-dev/prompts/04-tester-agent.md, write comprehensive tests for the implemented feature.
 
 # 5. Security Review
-Using @workspace .ai-dev/prompts/07-security-reviewer-agent.md, review the implementation for security concerns.
+Using @workspace ai-dev/prompts/07-security-reviewer-agent.md, review the implementation for security concerns.
 
 # 6. Documentation  
-Using @workspace .ai-dev/prompts/06-documenter-agent.md, create documentation for the feature.
+Using @workspace ai-dev/prompts/06-documenter-agent.md, create documentation for the feature.
 
 # 7. Archive
-Using @workspace .ai-dev/prompts/08-archiver-agent.md, create an entry in @workspace AIDEV.md titled 'Feature: [Name]'.
+Using @workspace ai-dev/prompts/08-archiver-agent.md, create an entry in @workspace AIDEV.md titled 'Feature: [Name]'.
 
 # Incident Management (When Issues Arise)
-Using @workspace .ai-dev/prompts/10-incident-triage-agent.md, analyze production errors.
-Using @workspace .ai-dev/prompts/11-incident-fix-agent.md, plan incident response.
+Using @workspace ai-dev/prompts/10-incident-triage-agent.md, analyze production errors.
+Using @workspace ai-dev/prompts/11-incident-fix-agent.md, plan incident response.
 ```
 
 **GitHub Copilot Workflow:**
@@ -475,7 +475,7 @@ Using @workspace .ai-dev/prompts/11-incident-fix-agent.md, plan incident respons
 - **`.ai-dev/config/variables.json`**: Project-specific variables
 - **`.github/copilot-instructions.md`**: Coding standards and context
 - **`AIDEV.md`**: Development history and decisions
-- **Agent prompts in `.ai-dev/prompts/`**: Project-specific guidance
+- **Agent prompts in `ai-dev/prompts/`**: Project-specific guidance
 
 ## Success Indicators
 


### PR DESCRIPTION
…mpts/

CRITICAL: Fixed incorrect directory references throughout documentation
- Agent templates are in ai-dev/prompts/ (no dot prefix)
- Memory/scratchpad remains in .ai-dev/memory/ (with dot prefix)
- Updated all @workspace commands and examples to use correct paths
- Ensures users can actually find and use the agent templates